### PR TITLE
Make tests pass if dateutil does not know the timezone

### DIFF
--- a/src/icalendar/tests/test_issue_722_generate_vtimezone.py
+++ b/src/icalendar/tests/test_issue_722_generate_vtimezone.py
@@ -410,4 +410,4 @@ def test_we_can_identify_dateutil_timezones(tzid):
     But if we know their shortcodes, we should be able to identify them.
     """
     tz = gettz(tzid)
-    assert tzid in tzids_from_tzinfo(tz)
+    assert tz is None or tzid in tzids_from_tzinfo(tz)


### PR DESCRIPTION
See https://github.com/collective/icalendar/issues/780#issuecomment-2759439855

This is my attempt to solve this test run.